### PR TITLE
Fix helm --set params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ tiller-deploy   1         1         1            1           3m
 Install the sandbox. Since Chirper only uses Cassandra, we're disabling the other services but you can leave them enabled by omitting the `set` flag if you wish.
 
 ```bash
-helm install lightbend-helm-charts/reactive-sandbox --name reactive-sandbox --set elasticsearch.enabled=0,kafka.enabled=0,zookeeper.enabled=0
+helm install lightbend-helm-charts/reactive-sandbox --name reactive-sandbox --set elasticsearch.enabled=false,kafka.enabled=false,zookeeper.enabled=false
 ```
 
 Verify that it is available (this takes a minute or two):


### PR DESCRIPTION
elasticsearch.enabled=0 - doesn't turn off it
elasticsearch.enabled=false - turns off

```
16:56 $ helm install lightbend-helm-charts/reactive-sandbox --name reactive-sandbox --set elasticsearch.enabled=off,kafka.enabled=false,zookeeper.enabled=0
NAME:   reactive-sandbox
LAST DEPLOYED: Wed Jan 31 16:56:16 2018
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME                            TYPE       CLUSTER-IP  EXTERNAL-IP  PORT(S)   AGE
reactive-sandbox-cassandra      ClusterIP  None        <none>       9042/TCP  0s
reactive-sandbox-elasticsearch  ClusterIP  None        <none>       9200/TCP  0s
reactive-sandbox-zookeeper      ClusterIP  None        <none>       2181/TCP  0s

==> v1beta1/Deployment
NAME              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
reactive-sandbox  1        1        1           0          0s
```

```
16:56 $ helm install lightbend-helm-charts/reactive-sandbox --name reactive-sandbox --set elasticsearch.enabled=false,kafka.enabled=false,zookeeper.enabled=false
NAME:   reactive-sandbox
LAST DEPLOYED: Wed Jan 31 16:56:58 2018
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME                        TYPE       CLUSTER-IP  EXTERNAL-IP  PORT(S)   AGE
reactive-sandbox-cassandra  ClusterIP  None        <none>       9042/TCP  0s

==> v1beta1/Deployment
NAME              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
reactive-sandbox  1        1        1           0          0s
```